### PR TITLE
Remove redundant strings from bot regex

### DIFF
--- a/lib/agent_orange/device.rb
+++ b/lib/agent_orange/device.rb
@@ -14,7 +14,7 @@ module AgentOrange
     DEVICES = {
       :computer => 'windows|macintosh|x11|linux',
       :mobile => 'ipod|ipad|iphone|palm|android|opera mini|hiptop|windows ce|smartphone|mobile|treo|psp',
-      :bot => 'bot|googlebot|crawler|spider|robot|crawling'
+      :bot => 'bot|crawler|spider|crawling'
     }
 
     def parse(user_agent)


### PR DESCRIPTION
The regex that determines if a user agent is a bot included "bot" but also a couple of redundant strings, namely "googlebot" and "robot".

This commit removes those redundant strings, allowing the regex to rely on matching just "bot".
