### PR TITLE
Improve bot detection regex

### DIFF
--- a/lib/agent_orange/device.rb
+++ b/lib/agent_orange/device.rb
@@ -14,7 +14,7 @@ module AgentOrange
     DEVICES = {
       :computer => 'windows|macintosh|x11|linux',
       :mobile => 'ipod|ipad|iphone|palm|android|opera mini|hiptop|windows ce|smartphone|mobile|treo|psp',
-      :bot => 'alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|nagios|postrank|pingdom|slurp|spider|yahoo!'
+      :bot => 'alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|google web preview|nagios|postrank|pingdom|slurp|spider|yahoo!'
     }
 
     def parse(user_agent)

--- a/lib/agent_orange/device.rb
+++ b/lib/agent_orange/device.rb
@@ -14,7 +14,7 @@ module AgentOrange
     DEVICES = {
       :computer => 'windows|macintosh|x11|linux',
       :mobile => 'ipod|ipad|iphone|palm|android|opera mini|hiptop|windows ce|smartphone|mobile|treo|psp',
-      :bot => 'alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|google web preview|nagios|postrank|pingdom|slurp|spider|yahoo!'
+      :bot => 'alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|google web preview|nagios|postrank|pingdom|slurp|spider|yahoo!|yandex'
     }
 
     def parse(user_agent)

--- a/lib/agent_orange/device.rb
+++ b/lib/agent_orange/device.rb
@@ -14,7 +14,7 @@ module AgentOrange
     DEVICES = {
       :computer => 'windows|macintosh|x11|linux',
       :mobile => 'ipod|ipad|iphone|palm|android|opera mini|hiptop|windows ce|smartphone|mobile|treo|psp',
-      :bot => 'bot|googlebot|crawler|spider|robot|crawling'
+      :bot => 'alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|nagios|postrank|pingdom|slurp|spider|yahoo!'
     }
 
     def parse(user_agent)


### PR DESCRIPTION
This pull request improves the bot detection regex by:
- adding a number of missing strings, such as alexa, facebookexternalhit, feedburner, google web preview, nagios, postrank, pingdom, slurp, yahoo!, and yandex
- removing redundant strings such as googlebot and robot (redundant because of the inclusion of a general "bot" string)
- consolidating similar strings ("crawler" and "crawling" became "crawl(er|ing)")
- alphabetizing the list of bots
