### PR TITLE
Added support for is_mobile? returning true for Google's smartphone crawler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in agent_orange.gemspec
 gemspec
+gem 'rspec'

--- a/README.rdoc
+++ b/README.rdoc
@@ -163,6 +163,7 @@ A warm thank you to all contributors to the project, who have put effort and tim
 * David Rice (@davidjrice) - RSpec tests and bug fixes.
 * Joshua Siler (@eatenbyagrue) - Bot detection, initial test, and bug fixes.
 * Alexander Rozumiy (@brain-geek) - Rspec testing for 1.9, updated travis-ci config, updated useragents to test against.
+* Joe Lencioni (@lencioni) - Improved bot detection.
 
 == License
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -78,7 +78,7 @@ If you're going to use it with Rails then add the gem to your Gemfile.
   
 === Looking at the operating system
 
-  >> os = ua.device.os
+  >> os = ua.device.operating_system
   => "iPhone OS 4.3"
   >> os.type
   => "iphone_os"

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'bundler/gem_tasks'
+require 'rake/dsl_definition'
 Dir.glob('./lib/tasks/*.rake').each { |r| import r }
 
 begin
@@ -9,6 +10,5 @@ begin
     # t.pattern = "./spec/**/*_spec.rb" # don't need this, it's default.
     # Put spec opts in a file named .rspec in root
   end
-
   task :default => :spec
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,6 @@
 require 'rubygems'
-require 'bundler'
-begin
-  Bundler.setup(:default, :development)
-rescue Bundler::BundlerError => e
-  $stderr.puts e.message
-  $stderr.puts "Run `bundle install` to install missing gems"
-  exit e.status_code
-end
-
-require File.join(File.dirname(__FILE__), "user_agent_matcher")
-
+require 'bundler/setup'
+require File.join(File.dirname(__FILE__), 'user_agent_matcher')
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -9,6 +9,7 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.operating_system.name.should == "Mac OS X"
       ua.device.operating_system.version.to_s.should == "10.6.8"
@@ -29,6 +30,7 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.operating_system.name.should == "Linux"
       ua.device.operating_system.version.to_s.should == "i686"
@@ -50,6 +52,7 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.operating_system.name.should == "Windows"
       ua.device.operating_system.version.to_s.should == "5.1"
@@ -68,6 +71,7 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.operating_system.name.should == "Mac OS X"
       ua.device.operating_system.version.to_s.should == "10.7.1"
@@ -86,9 +90,39 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.engine.browser.name.should == "Chrome"
       ua.device.engine.browser.version.to_s.should == "13.0.782.218"
     end
+  end
+  
+  describe "Google User Agents" do
+    detect "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)" do |ua|
+      ua.device.type.should == :mobile
+      ua.device.name.should == "Mobile"
+      ua.device.version.should == nil
+      ua.device.bot.should == true
+      ua.is_mobile?.should == true
+      ua.is_computer?.should == false
+      ua.is_bot?.should == true
+
+      ua.device.engine.browser.name.should == "Safari"
+      ua.device.engine.browser.version.to_s.should == "6531.22.7"    
+    end
+    
+    detect "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" do |ua|
+      ua.device.type.should == :bot
+      ua.device.name.should == "Bot"
+      ua.device.version.should == nil
+      ua.device.bot.should == true
+      ua.is_mobile?.should == false
+      ua.is_computer?.should == false
+      ua.is_bot?.should == true
+
+      ua.device.engine.browser.name.should == nil
+      ua.device.engine.browser.version.to_s.should == ""
+    end
+    
   end
 end


### PR DESCRIPTION
Google has both desktop and mobile crawlers:

https://developers.google.com/webmasters/smartphone-sites/googlebot-mobile

This change makes it so is_mobile? returns true AND is_bot? returns true for the Google smartphone crawler and includes specs for both the desktop and mobile user agent. I opted to stay backwards compatible for the standard Google crawler user agent so that is_computer? continues to return false. 
