### PR TITLE
Added support for is_mobile? returning true on Google's mobile web

### DIFF
--- a/lib/agent_orange/device.rb
+++ b/lib/agent_orange/device.rb
@@ -6,14 +6,17 @@ require 'agent_orange/version'
 
 module AgentOrange
   class Device < Base
-    attr_accessor :type, :name, :version
+    attr_accessor :type, :name, :version, :bot
     attr_accessor :platform
     attr_accessor :operating_system
     attr_accessor :engine
 
     DEVICES = {
       :computer => 'windows|macintosh|x11|linux',
-      :mobile => 'ipod|ipad|iphone|palm|android|opera mini|hiptop|windows ce|smartphone|mobile|treo|psp',
+      :mobile => 'ipod|ipad|iphone|palm|android|opera mini|hiptop|windows ce|smartphone|mobile|treo|psp'
+    }
+
+    BOTS = {
       :bot => 'alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|google web preview|nagios|postrank|pingdom|slurp|spider|yahoo!|yandex'
     }
 
@@ -22,7 +25,8 @@ module AgentOrange
 
       groups = parse_user_agent_string_into_groups(user_agent)
       groups.each_with_index do |content,i|
-        if content[:comment] =~ /(#{DEVICES.collect{|cat,regex| regex}.join(')|(')})/i
+        devices_and_bots = DEVICES.merge(BOTS)
+        if content[:comment] =~ /(#{devices_and_bots.collect{|cat,regex| regex}.join(')|(')})/i
           # Matched group against name
           self.populate(content)
         end
@@ -40,6 +44,10 @@ module AgentOrange
       AgentOrange.debug "", 2
 
       self.type = self.determine_type(DEVICES, content[:comment])
+      self.bot = self.determine_type(BOTS, content[:comment]) == :bot
+      if (self.bot && self.type == "other")
+        self.type = :bot # backwards compatability
+      end
       self.name = self.type.to_s.capitalize
       self.version = nil
       self
@@ -86,7 +94,7 @@ module AgentOrange
           return self.name.downcase.include?(name.to_s.downcase)
         end
       else
-        (self.type == :bot)
+        self.bot
       end
     end
 

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -9,6 +9,7 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.operating_system.name.should == "Mac OS X"
       ua.device.operating_system.version.to_s.should == "10.6.8"
@@ -29,6 +30,7 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.operating_system.name.should == "Linux"
       ua.device.operating_system.version.to_s.should == "i686"
@@ -50,6 +52,7 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.operating_system.name.should == "Windows"
       ua.device.operating_system.version.to_s.should == "5.1"
@@ -68,6 +71,7 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.operating_system.name.should == "Mac OS X"
       ua.device.operating_system.version.to_s.should == "10.7.1"
@@ -86,9 +90,39 @@ describe AgentOrange::UserAgent do
       ua.device.type.should == :computer
       ua.device.name.should == "Computer"
       ua.device.version.should == nil
+      ua.device.bot.should == false
 
       ua.device.engine.browser.name.should == "Chrome"
       ua.device.engine.browser.version.to_s.should == "13.0.782.218"
     end
+  end
+  
+  describe "Google User Agents" do
+    detect "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)" do |ua|
+      ua.device.type.should == :mobile
+      ua.device.name.should == "Mobile"
+      ua.device.version.should == nil
+      ua.device.bot.should == true
+      ua.is_mobile?.should == true
+      ua.is_computer?.should == false
+      ua.is_bot?.should == true
+
+      ua.device.engine.browser.name.should == "Safari"
+      ua.device.engine.browser.version.to_s.should == "6531.22.7"    
+    end
+    
+    detect "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" do |ua|
+      ua.device.type.should == :bot
+      ua.device.name.should == "Bot"
+      ua.device.version.should == nil
+      ua.device.bot.should == true
+      ua.is_mobile?.should == false
+      ua.is_computer?.should == false
+      ua.is_bot?.should == true
+
+      ua.device.engine.browser.name.should == nil
+      ua.device.engine.browser.version.to_s.should == ""
+    end
+    
   end
 end


### PR DESCRIPTION
Google has both desktop and mobile crawlers:

https://developers.google.com/webmasters/smartphone-sites/googlebot-mobile

This change makes it so is_mobile? returns true AND is_bot? returns true for the Google smartphone crawler and includes specs for both the desktop and mobile user agent. I opted to stay backwards compatible for the standard Google crawler user agent so that is_computer? continues to return false.
